### PR TITLE
Addresses issue #3 and #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Editor stuff:
+.idea/
+.vscode/

--- a/materialize_forms/templates/materialize/field_errors.html
+++ b/materialize_forms/templates/materialize/field_errors.html
@@ -1,5 +1,3 @@
 {% if field.errors %}
-    {% for error in field.errors %}
-        <span class="help-inline error">{{ error }}</span>
-    {% endfor %}
+    <span class="helper-text" data-error="{{ field.errors.0 }}"></span>
 {% endif %}

--- a/materialize_forms/templates/materialize/field_help.html
+++ b/materialize_forms/templates/materialize/field_help.html
@@ -1,5 +1,7 @@
 {% if field.help_text %}
     {% autoescape off %}
-        <span class="help-inline">{{ field.help_text }}</span>
+        {% if not field.errors %}
+            <span class="help-inline">{{ field.help_text }}</span>
+        {% endif %}
     {% endautoescape %}
 {% endif %}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -25,9 +25,7 @@
                 <span style="color: red;">*</span>
             {% endif %}
         </label>
-        {% if field.errors %}
-            <span class="helper-text" data-error="{{ field.errors.0 }}"></span>
-        {% endif %}
+        {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "select" %}
     <div class="input-field col {{ col }}">
@@ -41,11 +39,11 @@
             {% endif %}
         </label>
         {% include "materialize/field_help.html" %}
+        {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "file" %}
     <div class="col {{ col }}">
-        <label for="{{ field.auto_id }}" 
-               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
+        <label for="{{ field.auto_id }}">
             {{ field.label }}
 
             {% if field.field.required %}
@@ -66,14 +64,14 @@
     </div>
 {% elif input_type == "date" or input_type == "time" %}
     <div class="col {{ col }}" style="position: relative;">
-        <label for="{{ field.auto_id }}"
-               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
+        <label for="{{ field.auto_id }}">
             {{ field.label }}
             {% if field.field.required %}
                 <span style="color: red;">*</span>
             {% endif %}
         </label>
         {{ field }}
+        {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "tel" %}
     <div class="input-field col {{ col }}" style="position: relative;">
@@ -84,15 +82,12 @@
             {% endif %}
         </label>
         {{ field }}
-        {% if field.errors %}
-            <span class="helper-text" data-error="{{ field.errors.0 }}"></span>
-        {% endif %}
+        {% include "materialize/field_errors.html" %}
     </div>
 {% else %}
     {# treat all other input_types as a text input field #}
     <div class="col {{ col }}" style="padding:10px">
-        <label for="{{ field.auto_id }}" style="margin-bottom:10px;"
-               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
+        <label for="{{ field.auto_id }}" style="margin-bottom:10px;">
             {{ field.label }}
 
             {% if field.field.required %}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -1,5 +1,5 @@
 {% if input_type == "checkbox" %}
-    <div style = "padding:10px">
+    <div style="padding:10px">
         {{ field }}
         <label for="{{ field.auto_id }}">{{ field.label }}</label>
         {% include "materialize/field_help.html" %}
@@ -18,34 +18,23 @@
         {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "file" %}
-    <div class="file-field input-field col {{ col }}">
-        <div class="btn">
-            <span>File</span>
-              {{ field }}
-              {% include "materialize/field_help.html" %}
-              {% include "materialize/field_errors.html" %}
-        </div>
-        <div class="file-path-wrapper">
-            <input class="file-path validate" type="text" placeholder="{{ field.label }}">
+    <div class="col {{ col }}">
+        <label >{{ field.label }}</label>
+        <div class="file-field input-field">
+            <div class="btn">
+                <span>File</span>
+                {{ field }}
+            </div>
+            <div class="file-path-wrapper">
+                <input class="file-path validate" type="text" placeholder="{{ field.help_text }}">
+            </div>
+            {% include "materialize/field_errors.html" %}
         </div>
     </div>
-  <!--<div class="file-field input-field col {{ col }}">-->
-
-      <!--<div class="row">-->
-         <!--<div class="col">-->
-             <!--<label for="{{ field.auto_id }}">{{ field.label }}</label>-->
-         <!--</div>-->
-         <!--<div class="btn col push-s1">-->
-             <!--<span>{{field.name}}</span>-->
-             <!--{{ field }}-->
-
-         <!--</div>-->
-      <!--</div>-->
-  <!--</div>-->
 {% else %}
-{# treat all other input_types as a text input field #}
+    {# treat all other input_types as a text input field #}
     <div class="col {{ col }}" style="padding:10px">
-        <label for="{{ field.auto_id }}" style = "margin-bottom:10px;">{{ field.label }}</label>
+        <label for="{{ field.auto_id }}" style="margin-bottom:10px;">{{ field.label }}</label>
         <br/>
         <br/>
         {{ field }}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -1,52 +1,44 @@
 {% if input_type == "checkbox" %}
     <div style = "padding:10px">
-      {{ field }}
-      <label for="{{ field.auto_id }}">{{ field.label }}</label>
-      {% include "materialize/field_help.html" %}
+        {{ field }}
+        <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        {% include "materialize/field_help.html" %}
     </div>
-{% else %}
-    {% if input_type == "multicheckbox" %}
-        {% include "materialize/field_choices.html" with type="checkbox" %}
-        {% include "materialize/field_help.html" with display="block" %}
-    {% else %}
-        {% if input_type == "radioset" %}
-            {% include "materialize/field_choices.html" with type="radio" %}
-            {% include "materialize/field_help.html" with display="block" %}
-        {% else %}
-            {% if input_type == "text" or input_type == "textarea" %}
-            <div class="input-field col {{ col }}">
-                <label for="{{ field.auto_id }}">{{ field.label }}</label>
-                {{ field }}
-                {% include "materialize/field_help.html" %}
-                {% include "materialize/field_errors.html" %}
-            </div>
-            {% else %}
-               {% if input_type == "default" %}
-               {# for file fields#}
-                  <div class=" file-field input-field col {{ col }}">
-                      <div class = "row">
-                         <div class = "col">
-                             <label for="{{ field.auto_id }}">{{ field.label }}</label>
-                         </div>
-                         <div class = "btn col push-s1">
-                             <span>{{field.name}}</span>
-                             {{ field }}
-                             {% include "materialize/field_help.html" %}
-                             {% include "materialize/field_errors.html" %}
-                         </div>
-                      </div>
-                  </div>
-               {%else%}
-                  <div class="col {{ col }}" style="padding:10px">
-                      <label for="{{ field.auto_id }}" style = "margin-bottom:10px;">{{ field.label }}</label>
-                      <br/>
-                      <br/>
-                      {{ field }}
-                      {% include "materialize/field_help.html" %}
-                      {% include "materialize/field_errors.html" %}
-                  </div>
-                {%endif%}
-            {% endif %}
-        {% endif %}
-    {% endif %}
-{% endif %}
+{% elif input_type == "multicheckbox" %}
+    {% include "materialize/field_choices.html" with type="checkbox" %}
+    {% include "materialize/field_help.html" with display="block" %}
+{% elif input_type == "radioset" %}
+    {% include "materialize/field_choices.html" with type="radio" %}
+    {% include "materialize/field_help.html" with display="block" %}
+{% elif input_type == "text" or input_type == "textarea" or input_type == "url" or input_type == "email" %}
+    <div class="input-field col {{ col }}">
+        <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        {{ field }}
+        {% include "materialize/field_help.html" %}
+        {% include "materialize/field_errors.html" %}
+    </div>
+{% elif input_type == "file" %}
+  <div class="file-field input-field col {{ col }}">
+      <div class="row">
+         <div class="col">
+             <label for="{{ field.auto_id }}">{{ field.label }}</label>
+         </div>
+         <div class="btn col push-s1">
+             <span>{{field.name}}</span>
+             {{ field }}
+             {% include "materialize/field_help.html" %}
+             {% include "materialize/field_errors.html" %}
+         </div>
+      </div>
+  </div>
+{%else%}
+{# treat all other input_types as a text input field #}
+    <div class="col {{ col }}" style="padding:10px">
+        <label for="{{ field.auto_id }}" style = "margin-bottom:10px;">{{ field.label }}</label>
+        <br/>
+        <br/>
+        {{ field }}
+        {% include "materialize/field_help.html" %}
+        {% include "materialize/field_errors.html" %}
+    </div>
+{%endif%}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -12,7 +12,6 @@
     {% include "materialize/field_help.html" with display="block" %}
 {% elif input_type == "text" or input_type == "textarea" or input_type == "url" or input_type == "email" %}
     <div class="input-field col {{ col }}">
-        text field
         {{ field }}
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -18,19 +18,30 @@
         {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "file" %}
-  <div class="file-field input-field col {{ col }}">
-      <div class="row">
-         <div class="col">
-             <label for="{{ field.auto_id }}">{{ field.label }}</label>
-         </div>
-         <div class="btn col push-s1">
-             <span>{{field.name}}</span>
-             {{ field }}
-             {% include "materialize/field_help.html" %}
-             {% include "materialize/field_errors.html" %}
-         </div>
-      </div>
-  </div>
+    <div class="file-field input-field col {{ col }}">
+        <div class="btn">
+            <span>File</span>
+              {{ field }}
+              {% include "materialize/field_help.html" %}
+              {% include "materialize/field_errors.html" %}
+        </div>
+        <div class="file-path-wrapper">
+            <input class="file-path validate" type="text" placeholder="{{ field.label }}">
+        </div>
+    </div>
+  <!--<div class="file-field input-field col {{ col }}">-->
+
+      <!--<div class="row">-->
+         <!--<div class="col">-->
+             <!--<label for="{{ field.auto_id }}">{{ field.label }}</label>-->
+         <!--</div>-->
+         <!--<div class="btn col push-s1">-->
+             <!--<span>{{field.name}}</span>-->
+             <!--{{ field }}-->
+
+         <!--</div>-->
+      <!--</div>-->
+  <!--</div>-->
 {% else %}
 {# treat all other input_types as a text input field #}
     <div class="col {{ col }}" style="padding:10px">

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -7,7 +7,7 @@
 {% elif input_type == "multicheckbox" %}
     {% include "materialize/field_choices.html" with type="checkbox" %}
     {% include "materialize/field_help.html" with display="block" %}
-{% elif input_type == "radioset" %}
+{% elif input_type == "radio" %}
     {% include "materialize/field_choices.html" with type="radio" %}
     {% include "materialize/field_help.html" with display="block" %}
 {% elif input_type == "text" or input_type == "textarea" or input_type == "url" or input_type == "email" %}
@@ -31,7 +31,7 @@
          </div>
       </div>
   </div>
-{%else%}
+{% else %}
 {# treat all other input_types as a text input field #}
     <div class="col {{ col }}" style="padding:10px">
         <label for="{{ field.auto_id }}" style = "margin-bottom:10px;">{{ field.label }}</label>
@@ -41,4 +41,4 @@
         {% include "materialize/field_help.html" %}
         {% include "materialize/field_errors.html" %}
     </div>
-{%endif%}
+{% endif %}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -30,14 +30,15 @@
 {% elif input_type == "select" %}
     <div class="input-field col {{ col }}">
         {{ field }}
-        <label for="{{ field.auto_id }}">
+        <label for="{{ field.auto_id }}"
+               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
             {{ field.label }}
 
             {% if field.field.required %}
                 <span style="color: red;">*</span>
             {% endif %}
         </label>
-        {% include "materialize/field_errors.html" %}
+        {% include "materialize/field_help.html" %}
     </div>
 {% elif input_type == "file" %}
     <div class="col {{ col }}">

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -13,7 +13,12 @@
 {% elif input_type == "text" or input_type == "textarea" or input_type == "url" or input_type == "email" %}
     <div class="input-field col {{ col }}">
         {{ field }}
-        <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        <label for="{{ field.auto_id }}">
+            {{ field.label }}
+            {% if field.required %}
+                <span style="color: red; margin-left: 3px;">*</span>
+            {% endif %}
+        </label>
         {% include "materialize/field_help.html" %}
         {% include "materialize/field_errors.html" %}
     </div>

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -73,6 +73,17 @@
         </label>
         {{ field }}
     </div>
+{% elif input_type == "tel" %}
+    <div class="col {{ col }}" style="position: relative;">
+        <label for="{{ field.auto_id }}"
+               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
+            {{ field.label }}
+            {% if field.field.required %}
+                <span style="color: red;">*</span>
+            {% endif %}
+        </label>
+        {{ field }}
+    </div>
 {% else %}
     {# treat all other input_types as a text input field #}
     <div class="col {{ col }}" style="padding:10px">

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -61,7 +61,7 @@
         </div>
     </div>
 {% elif input_type == "date" or input_type == "time" %}
-    <div class="col {{ col }}">
+    <div class="col {{ col }}" style="position: relative;">
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
             {{ field.label }}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -17,6 +17,13 @@
         {% include "materialize/field_help.html" %}
         {% include "materialize/field_errors.html" %}
     </div>
+{% elif input_type == "select" %}
+    <div class="input-field col {{ col }}">
+        {{ field }}
+        <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        {% include "materialize/field_help.html" %}
+        {% include "materialize/field_errors.html" %}
+    </div>
 {% elif input_type == "file" %}
     <div class="col {{ col }}">
         <label for="{{ field.auto_id }}">{{ field.label }}</label>

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -1,8 +1,9 @@
 {% if input_type == "checkbox" %}
     <div style="padding:10px" {% if col %}class="col {{ col }}"{% endif %}>
-        {{ field }}
-        <label for="{{ field.auto_id }}">
-            {{ field.label }}
+        <label>
+            {{ field }}
+            
+            <span>{{ field.label }}</span>
 
             {% if field.field.required %}
                 <span style="color: red;">*</span>

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -74,7 +74,7 @@
         {{ field }}
     </div>
 {% elif input_type == "tel" %}
-    <div class="col {{ col }}" style="position: relative;">
+    <div class="input-field col {{ col }}" style="position: relative;">
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
             {{ field.label }}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -12,8 +12,8 @@
     {% include "materialize/field_help.html" with display="block" %}
 {% elif input_type == "text" or input_type == "textarea" or input_type == "url" or input_type == "email" %}
     <div class="input-field col {{ col }}">
-        <label for="{{ field.auto_id }}">{{ field.label }}</label>
         {{ field }}
+        <label for="{{ field.auto_id }}">{{ field.label }}</label>
         {% include "materialize/field_help.html" %}
         {% include "materialize/field_errors.html" %}
     </div>
@@ -38,6 +38,14 @@
             </div>
             {% include "materialize/field_errors.html" %}
         </div>
+    </div>
+{% elif input_type == "date" %}
+    <div class="col {{ col }}">
+        <label for="{{ field.auto_id }}"
+               data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
+            {{ field.label }}
+        </label>
+        {{ field }}
     </div>
 {% else %}
     {# treat all other input_types as a text input field #}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -1,5 +1,5 @@
 {% if input_type == "checkbox" %}
-    <div style="padding:10px">
+    <div style="padding:10px" {% if col %}class="col {{ col }}"{% endif %}>
         {{ field }}
         <label for="{{ field.auto_id }}">{{ field.label }}</label>
         {% include "materialize/field_help.html" %}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -12,15 +12,15 @@
     {% include "materialize/field_help.html" with display="block" %}
 {% elif input_type == "text" or input_type == "textarea" or input_type == "url" or input_type == "email" %}
     <div class="input-field col {{ col }}">
+        text field
         {{ field }}
-        <label for="{{ field.auto_id }}">
+        <label for="{{ field.auto_id }}"
+               data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
             {{ field.label }}
             {% if field.field.required %}
-                <span style="color: red; margin-left: 3px;">*</span>
+                <span style="color: red;">*</span>
             {% endif %}
         </label>
-        {% include "materialize/field_help.html" %}
-        {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "select" %}
     <div class="input-field col {{ col }}">
@@ -46,6 +46,7 @@
     </div>
 {% elif input_type == "date" or input_type == "time" %}
     <div class="col {{ col }}">
+        {{ field }}
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
             {{ field.label }}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -19,12 +19,13 @@
     </div>
 {% elif input_type == "file" %}
     <div class="col {{ col }}">
-        <label >{{ field.label }}</label>
+        <label for="{{ field.auto_id }}">{{ field.label }}</label>
         <div class="file-field input-field">
             <div class="btn">
                 <span>File</span>
                 {{ field }}
             </div>
+
             <div class="file-path-wrapper">
                 <input class="file-path validate" type="text" placeholder="{{ field.help_text }}">
             </div>

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -30,16 +30,17 @@
 {% elif input_type == "select" %}
     <div class="input-field col {{ col }}">
         {{ field }}
-        <label for="{{ field.auto_id }}"
-               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
+        <label for="{{ field.auto_id }}">
             {{ field.label }}
 
             {% if field.field.required %}
                 <span style="color: red;">*</span>
             {% endif %}
         </label>
+        {% if field.errors %}
+            <span style="color: red;">{{ field.errors.0 }}</span>
+        {% endif %}
         {% include "materialize/field_help.html" %}
-        {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "file" %}
     <div class="col {{ col }}">

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -19,13 +19,15 @@
 {% elif input_type == "text" or input_type == "textarea" or input_type == "url" or input_type == "email" %}
     <div class="input-field col {{ col }}">
         {{ field }}
-        <label for="{{ field.auto_id }}"
-               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
+        <label for="{{ field.auto_id }}">
             {{ field.label }}
             {% if field.field.required %}
                 <span style="color: red;">*</span>
             {% endif %}
         </label>
+        {% if field.errors %}
+            <span class="helper-text" data-error="{{ field.errors.0 }}"></span>
+        {% endif %}
     </div>
 {% elif input_type == "select" %}
     <div class="input-field col {{ col }}">
@@ -75,14 +77,16 @@
     </div>
 {% elif input_type == "tel" %}
     <div class="input-field col {{ col }}" style="position: relative;">
-        <label for="{{ field.auto_id }}"
-               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
+        <label for="{{ field.auto_id }}">
             {{ field.label }}
             {% if field.field.required %}
                 <span style="color: red;">*</span>
             {% endif %}
         </label>
         {{ field }}
+        {% if field.errors %}
+            <span class="helper-text" data-error="{{ field.errors.0 }}"></span>
+        {% endif %}
     </div>
 {% else %}
     {# treat all other input_types as a text input field #}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -45,7 +45,6 @@
     </div>
 {% elif input_type == "date" or input_type == "time" %}
     <div class="col {{ col }}">
-        {{ field }}
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
             {{ field.label }}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -20,7 +20,7 @@
     <div class="input-field col {{ col }}">
         {{ field }}
         <label for="{{ field.auto_id }}"
-               data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
+               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
             {{ field.label }}
             {% if field.field.required %}
                 <span style="color: red;">*</span>
@@ -31,7 +31,7 @@
     <div class="input-field col {{ col }}">
         {{ field }}
         <label for="{{ field.auto_id }}"
-               data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
+               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
             {{ field.label }}
 
             {% if field.field.required %}
@@ -63,7 +63,7 @@
 {% elif input_type == "date" or input_type == "time" %}
     <div class="col {{ col }}">
         <label for="{{ field.auto_id }}"
-               data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
+               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
             {{ field.label }}
             {% if field.field.required %}
                 <span style="color: red;">*</span>

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -39,7 +39,7 @@
             {% include "materialize/field_errors.html" %}
         </div>
     </div>
-{% elif input_type == "date" %}
+{% elif input_type == "date" or input_type == "time" %}
     <div class="col {{ col }}">
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -58,8 +58,8 @@
 
             <div class="file-path-wrapper">
                 <input class="file-path validate" type="text" placeholder="{{ field.help_text }}">
+                {% include "materialize/field_errors.html" %}
             </div>
-            {% include "materialize/field_errors.html" %}
         </div>
     </div>
 {% elif input_type == "date" or input_type == "time" %}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -30,18 +30,19 @@
 {% elif input_type == "select" %}
     <div class="input-field col {{ col }}">
         {{ field }}
-        <label for="{{ field.auto_id }}"
-               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
+        <label for="{{ field.auto_id }}">
             {{ field.label }}
 
             {% if field.field.required %}
                 <span style="color: red;">*</span>
             {% endif %}
         </label>
+        {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "file" %}
     <div class="col {{ col }}">
-        <label for="{{ field.auto_id }}">
+        <label for="{{ field.auto_id }}" 
+               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
             {{ field.label }}
 
             {% if field.field.required %}
@@ -74,7 +75,8 @@
 {% else %}
     {# treat all other input_types as a text input field #}
     <div class="col {{ col }}" style="padding:10px">
-        <label for="{{ field.auto_id }}" style="margin-bottom:10px;">
+        <label for="{{ field.auto_id }}" style="margin-bottom:10px;"
+               data-error="{% if field.errors %}{{ field.errors.0 }}{% endif %}">
             {{ field.label }}
 
             {% if field.field.required %}

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -15,7 +15,7 @@
         {{ field }}
         <label for="{{ field.auto_id }}">
             {{ field.label }}
-            {% if field.required %}
+            {% if field.field.required %}
                 <span style="color: red; margin-left: 3px;">*</span>
             {% endif %}
         </label>

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -30,15 +30,14 @@
 {% elif input_type == "select" %}
     <div class="input-field col {{ col }}">
         {{ field }}
-        <label for="{{ field.auto_id }}">
+        <label for="{{ field.auto_id }}"
+               data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
             {{ field.label }}
 
             {% if field.field.required %}
                 <span style="color: red;">*</span>
             {% endif %}
         </label>
-        {% include "materialize/field_help.html" %}
-        {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "file" %}
     <div class="col {{ col }}">

--- a/materialize_forms/templates/materialize/field_visible.html
+++ b/materialize_forms/templates/materialize/field_visible.html
@@ -1,7 +1,13 @@
 {% if input_type == "checkbox" %}
     <div style="padding:10px" {% if col %}class="col {{ col }}"{% endif %}>
         {{ field }}
-        <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        <label for="{{ field.auto_id }}">
+            {{ field.label }}
+
+            {% if field.field.required %}
+                <span style="color: red;">*</span>
+            {% endif %}
+        </label>
         {% include "materialize/field_help.html" %}
     </div>
 {% elif input_type == "multicheckbox" %}
@@ -24,13 +30,25 @@
 {% elif input_type == "select" %}
     <div class="input-field col {{ col }}">
         {{ field }}
-        <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        <label for="{{ field.auto_id }}">
+            {{ field.label }}
+
+            {% if field.field.required %}
+                <span style="color: red;">*</span>
+            {% endif %}
+        </label>
         {% include "materialize/field_help.html" %}
         {% include "materialize/field_errors.html" %}
     </div>
 {% elif input_type == "file" %}
     <div class="col {{ col }}">
-        <label for="{{ field.auto_id }}">{{ field.label }}</label>
+        <label for="{{ field.auto_id }}">
+            {{ field.label }}
+
+            {% if field.field.required %}
+                <span style="color: red;">*</span>
+            {% endif %}
+        </label>
         <div class="file-field input-field">
             <div class="btn">
                 <span>File</span>
@@ -48,13 +66,22 @@
         <label for="{{ field.auto_id }}"
                data-error="{% if field.errors %}{{ field.errors.0.error }}{% endif %}">
             {{ field.label }}
+            {% if field.field.required %}
+                <span style="color: red;">*</span>
+            {% endif %}
         </label>
         {{ field }}
     </div>
 {% else %}
     {# treat all other input_types as a text input field #}
     <div class="col {{ col }}" style="padding:10px">
-        <label for="{{ field.auto_id }}" style="margin-bottom:10px;">{{ field.label }}</label>
+        <label for="{{ field.auto_id }}" style="margin-bottom:10px;">
+            {{ field.label }}
+
+            {% if field.field.required %}
+                <span style="color: red;">*</span>
+            {% endif %}
+        </label>
         <br/>
         <br/>
         {{ field }}

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -30,9 +30,8 @@ def as_material(field, col='s6'):
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
 
-    if field.field.required:
-        if field.field.label:
-            field.field.label += '<span style="color: red; margin-left: 3px;">*</span>'
+    if field.field.required and field.label:
+            field.label += '<span style="color: red; margin-left: 3px;">*</span>'
 
     if isinstance(field.field, CharField) and field.help_text:
         placeholder_attr = {'placeholder': field.help_text}

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,9 +33,9 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         add_css_class_widget(widget, 'datepicker')
 
-    if widget.input_type:
+    try:
         input_type = widget.input_type
-    else:
+    except AttributeError:
         if isinstance(widget, widgets.Textarea):
             input_type = u'textarea'
             add_css_class_widget(widget, 'materialize-textarea')

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -19,7 +19,6 @@ def add_css_class_widget(widget, css_class):
 
 @register.filter
 def as_material(field, col='s6'):
-
     try:
         widget = field.field.widget
     except:
@@ -50,13 +49,11 @@ def as_material(field, col='s6'):
     else:
         input_type = u'default'
 
-    return get_template("materialize/field.html").render(
-        Context({
-            'field': field,
-            'col': col,
-            'input_type': input_type,
-        })
-    )
+    return get_template("materialize/field.html").render({
+        'field': field,
+        'col': col,
+        'input_type': input_type,
+    })
 
 
 @register.filter
@@ -65,5 +62,3 @@ def html_attrs(attrs):
     for name, value in attrs.items():
         pairs.append(u'%s="%s"' % (escape(name), escape(value)))
     return mark_safe(u' '.join(pairs))
-
-

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -30,6 +30,14 @@ def as_material(field, col='s6'):
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
 
+    # Because the above has already run, we can be sure the
+    # widget.attrs['class'] key is already present
+    if field.errors:
+        # There are django field errors, so add the invalid class to
+        # mark the field invalid in materialize
+        clazz = {'class': widget.attrs['class'] + ' invalid'}
+    widget.attrs.update(clazz)
+
     if isinstance(field.field, CharField) and field.help_text:
         placeholder_attr = {'placeholder': field.help_text}
         widget.attrs.update(placeholder_attr)

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,6 +33,7 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
+        widget.attrs['type'] = 'date'
     else:
         try:
             input_type = widget.input_type

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -30,9 +30,6 @@ def as_material(field, col='s6'):
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
 
-    if field.field.required and field.label:
-            field.label += '<span style="color: red; margin-left: 3px;">*</span>'
-
     if isinstance(field.field, CharField) and field.help_text:
         placeholder_attr = {'placeholder': field.help_text}
         widget.attrs.update(placeholder_attr)

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,11 +33,22 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         add_css_class_widget(widget, 'datepicker')
 
-    if isinstance(widget, widgets.Textarea):
-        input_type = u'textarea'
-        add_css_class_widget(widget, 'materialize-textarea')
-    else:
+    if widget.input_type:
         input_type = widget.input_type
+    else:
+        if isinstance(widget, widgets.Textarea):
+            input_type = u'textarea'
+            add_css_class_widget(widget, 'materialize-textarea')
+        elif isinstance(widget, widgets.CheckboxInput):
+            input_type = u'checkbox'
+        elif isinstance(widget, widgets.CheckboxSelectMultiple):
+            input_type = u'multicheckbox'
+        elif isinstance(widget, widgets.RadioSelect):
+            input_type = u'radio'
+        elif isinstance(widget, widgets.Select):
+            input_type = u'select'
+        else:
+            input_type = u'default'
 
     return get_template("materialize/field.html").render({
         'field': field,

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,7 +33,7 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-        widget_type = {'test': 'data'}
+        widget_type = {'input_type': 'date'}
         widget.attrs.update(widget_type)
     else:
         try:

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -6,6 +6,8 @@ from django.template.loader import get_template
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
+from phonenumber_field.formfields import PhoneNumberField
+
 register = template.Library()
 
 
@@ -37,11 +39,16 @@ def as_material(field, col='s6'):
         # mark the field invalid in materialize
         clazz = {'class': widget.attrs['class'] + ' invalid'}
     widget.attrs.update(clazz)
+    if isinstance(field.field, PhoneNumberField):
+        widget.input_type = u'tel'
+        if field.help_text:
+            placeholder_attr = {'placeholder': field.help_text}
+            widget.attrs.update(placeholder_attr)
 
     if isinstance(field.field, CharField) and field.help_text:
         placeholder_attr = {'placeholder': field.help_text}
         widget.attrs.update(placeholder_attr)
-
+    
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,23 +33,23 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-
-    try:
-        input_type = widget.input_type
-    except AttributeError:
-        if isinstance(widget, widgets.Textarea):
-            input_type = u'textarea'
-            add_css_class_widget(widget, 'materialize-textarea')
-        elif isinstance(widget, widgets.CheckboxInput):
-            input_type = u'checkbox'
-        elif isinstance(widget, widgets.CheckboxSelectMultiple):
-            input_type = u'multicheckbox'
-        elif isinstance(widget, widgets.RadioSelect):
-            input_type = u'radio'
-        elif isinstance(widget, widgets.Select):
-            input_type = u'select'
-        else:
-            input_type = u'default'
+    else:
+        try:
+            input_type = widget.input_type
+        except AttributeError:
+            if isinstance(widget, widgets.Textarea):
+                input_type = u'textarea'
+                add_css_class_widget(widget, 'materialize-textarea')
+            elif isinstance(widget, widgets.CheckboxInput):
+                input_type = u'checkbox'
+            elif isinstance(widget, widgets.CheckboxSelectMultiple):
+                input_type = u'multicheckbox'
+            elif isinstance(widget, widgets.RadioSelect):
+                input_type = u'radio'
+            elif isinstance(widget, widgets.Select):
+                input_type = u'select'
+            else:
+                input_type = u'default'
 
     return get_template("materialize/field.html").render({
         'field': field,

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -31,7 +31,8 @@ def as_material(field, col='s6'):
     widget.attrs.update(clazz)
 
     if field.field.required:
-        field.field.label += '<span style="color: red; margin-left: 3px;">*</span>'
+        if field.field.label:
+            field.field.label += '<span style="color: red; margin-left: 3px;">*</span>'
 
     if isinstance(field.field, CharField) and field.help_text:
         placeholder_attr = {'placeholder': field.help_text}

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -1,6 +1,6 @@
 from django import template
 from django.forms import widgets
-from django.forms.fields import DateField, TimeField
+from django.forms.fields import DateField, TimeField, CharField
 from django.template import Context
 from django.template.loader import get_template
 from django.utils.html import escape
@@ -29,6 +29,10 @@ def as_material(field, col='s6'):
     except KeyError:
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
+
+    if isinstance(field.field, CharField) and field.help_text:
+        placeholder_attr = {'placeholder': field.help_text}
+        widget.attrs.update(placeholder_attr)
 
     if isinstance(field.field, DateField):
         input_type = u'date'

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -30,8 +30,6 @@ def as_material(field, col='s6'):
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
 
-    if isinstance(field.field, DateField):
-        add_css_class_widget(widget, 'datepicker')
 
     try:
         input_type = widget.input_type
@@ -39,6 +37,9 @@ def as_material(field, col='s6'):
         if isinstance(widget, widgets.Textarea):
             input_type = u'textarea'
             add_css_class_widget(widget, 'materialize-textarea')
+        elif isinstance(field.field, DateField):
+            input_type = u'date'
+            add_css_class_widget(widget, 'datepicker')
         elif isinstance(widget, widgets.CheckboxInput):
             input_type = u'checkbox'
         elif isinstance(widget, widgets.CheckboxSelectMultiple):

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -32,9 +32,12 @@ def as_material(field, col='s6'):
 
     if isinstance(field.field, DateField):
         add_css_class_widget(widget, 'datepicker')
-
-    if isinstance(widget, widgets.TextInput):
+    elif isinstance(widget, widgets.TextInput):
         input_type = u'text'
+    elif isinstance(widget, widgets.EmailInput):
+        input_type = u'email'
+    elif isinstance(widget, widgets.URLInput):
+        input_type = u'url'
     elif isinstance(widget, widgets.Textarea):
         input_type = u'textarea'
         add_css_class_widget(widget, 'materialize-textarea')
@@ -46,6 +49,8 @@ def as_material(field, col='s6'):
         input_type = u'radioset'
     elif isinstance(widget, widgets.Select):
         input_type = u'select'
+    elif isinstance(widget, widgets.ClearableFileInput):
+        input_type = u'file'
     else:
         input_type = u'default'
 

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -32,27 +32,12 @@ def as_material(field, col='s6'):
 
     if isinstance(field.field, DateField):
         add_css_class_widget(widget, 'datepicker')
-    elif isinstance(widget, widgets.TextInput):
-        input_type = u'text'
-    elif isinstance(widget, widgets.EmailInput):
-        input_type = u'email'
-    elif isinstance(widget, widgets.URLInput):
-        input_type = u'url'
-    elif isinstance(widget, widgets.Textarea):
+
+    if isinstance(widget, widgets.Textarea):
         input_type = u'textarea'
         add_css_class_widget(widget, 'materialize-textarea')
-    elif isinstance(widget, widgets.CheckboxInput):
-        input_type = u'checkbox'
-    elif isinstance(widget, widgets.CheckboxSelectMultiple):
-        input_type = u'multicheckbox'
-    elif isinstance(widget, widgets.RadioSelect):
-        input_type = u'radioset'
-    elif isinstance(widget, widgets.Select):
-        input_type = u'select'
-    elif isinstance(widget, widgets.ClearableFileInput):
-        input_type = u'file'
     else:
-        input_type = u'default'
+        input_type = widget.input_type
 
     return get_template("materialize/field.html").render({
         'field': field,

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -30,6 +30,9 @@ def as_material(field, col='s6'):
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
 
+    if field.field.required:
+        field.field.label += '<span style="color: red; margin-left: 3px;">*</span>'
+
     if isinstance(field.field, CharField) and field.help_text:
         placeholder_attr = {'placeholder': field.help_text}
         widget.attrs.update(placeholder_attr)

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,8 +33,6 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-        # widget_type = {'input_type': 'date'}
-        # widget.attrs.update(widget_type)
         widget.input_type = 'date'
     else:
         try:

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -1,6 +1,6 @@
 from django import template
 from django.forms import widgets
-from django.forms.fields import DateField
+from django.forms.fields import DateField, TimeField
 from django.template import Context
 from django.template.loader import get_template
 from django.utils.html import escape

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,7 +33,8 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-        widget.attrs['type'] = 'date'
+        widget_type = {'type': 'date'}
+        widget.attrs.update(widget_type)
     else:
         try:
             input_type = widget.input_type

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,7 +33,7 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-        widget_type = {'type': 'date'}
+        widget_type = {'test': 'data'}
         widget.attrs.update(widget_type)
     else:
         try:

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -33,8 +33,9 @@ def as_material(field, col='s6'):
     if isinstance(field.field, DateField):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
-        widget_type = {'input_type': 'date'}
-        widget.attrs.update(widget_type)
+        # widget_type = {'input_type': 'date'}
+        # widget.attrs.update(widget_type)
+        widget.input_type = 'date'
     else:
         try:
             input_type = widget.input_type

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -34,6 +34,10 @@ def as_material(field, col='s6'):
         input_type = u'date'
         add_css_class_widget(widget, 'datepicker')
         widget.input_type = 'date'
+    elif isinstance(field.field, TimeField):
+        input_type = u'time'
+        add_css_class_widget(widget, 'timepicker')
+        widget.input_type = 'time'
     else:
         try:
             input_type = widget.input_type

--- a/materialize_forms/templatetags/materialize.py
+++ b/materialize_forms/templatetags/materialize.py
@@ -30,6 +30,9 @@ def as_material(field, col='s6'):
         clazz = {'class': 'validate'}
     widget.attrs.update(clazz)
 
+    if isinstance(field.field, DateField):
+        input_type = u'date'
+        add_css_class_widget(widget, 'datepicker')
 
     try:
         input_type = widget.input_type
@@ -37,9 +40,6 @@ def as_material(field, col='s6'):
         if isinstance(widget, widgets.Textarea):
             input_type = u'textarea'
             add_css_class_widget(widget, 'materialize-textarea')
-        elif isinstance(field.field, DateField):
-            input_type = u'date'
-            add_css_class_widget(widget, 'datepicker')
         elif isinstance(widget, widgets.CheckboxInput):
             input_type = u'checkbox'
         elif isinstance(widget, widgets.CheckboxSelectMultiple):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django-materialize-forms',
-    version='0.2.0',
+    version='0.2.1',
     url='https://github.com/zokis/django-materialize-forms',
     author='Marcelo Fonseca Tambalo',
     author_email='marcelo.zokis@gmail.com',


### PR DESCRIPTION
Addresses issue #3 by not passing a Context directly to render(), since starting with Django 1.11 passing a Context instance raises a TypeError. Pass in a dict to `render()` instead, since `render()` creates a Context instance.

Relevant django source code (See `make_context()` at the very bottom of both of these pages):
[<1.10](https://docs.djangoproject.com/en/1.10/_modules/django/template/context/#Context) vs [1.11](https://docs.djangoproject.com/en/1.11/_modules/django/template/context/#Context)

Also addresses issue #5. Added conditional logic for EmailField and URLField.